### PR TITLE
update gh deployment to use hugo version 0.134.2

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2.6.0
         with:
-          hugo-version: '0.105.0'
+          hugo-version: '0.134.2'
 
       - name: Build
         run: hugo --minify


### PR DESCRIPTION
Fix CI failure: use hugo version 0.134.2 to support new breadcrumbs that use `.Ancestors`