### PR TITLE
Per-page title and description

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,10 @@
-title = 'Amadeus'
+title = "Amadeo's"
 theme = 'ama'
 baseURL = '//amadeusw.com'
 languageCode = 'en-us'
 
 [params]
   title = "Amadeo's website"
-  shortTitle = "Amadeo's"
   footerName = '//AW'
   summary = "projects programming travel"
+

--- a/config.toml
+++ b/config.toml
@@ -4,5 +4,7 @@ baseURL = '//amadeusw.com'
 languageCode = 'en-us'
 
 [params]
-  title = 'Amadeusz Wieczorek'
+  title = "Amadeo's website"
+  shortTitle = "Amadeo's"
   footerName = '//AW'
+  summary = "projects programming travel"

--- a/content/tech/setup/_index.md
+++ b/content/tech/setup/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Git setup"
 date: 2024-09-13T21:28:27-07:00
+description: Get in the flow in git
 summary: Get in the flow
 ---
 

--- a/themes/ama/layouts/partials/head.html
+++ b/themes/ama/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <head>
-    <title>{{.Params.title}} · {{.Site.Params.ShortTitle}}</title>
+    <title>{{.Params.title}} · {{.Site.Title}}</title>
     <link rel="stylesheet" href="{{.Site.BaseURL}}/css/style.css" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <meta name="description" content="{{.Params.title}} · {{.Params.summary}}" />
+    <meta name="description" content="{{.Description | default .Params.summary | default .Site.Params.summary}}" />
 </head>

--- a/themes/ama/layouts/partials/head.html
+++ b/themes/ama/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <head>
-    <title>Amadeus' page</title>
+    <title>{{.Params.title}} · {{.Site.Params.ShortTitle}}</title>
     <link rel="stylesheet" href="{{.Site.BaseURL}}/css/style.css" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <meta name="description" content="Personal website of Amadeusz Wieczorek about projects, travel and programming." />
+    <meta name="description" content="{{.Params.title}} · {{.Params.summary}}" />
 </head>


### PR DESCRIPTION
Previously, add links had title "Amadeusz Wieczorek" with description "Personal website of Amadeusz Wieczorek about projects, travel and programming." - this shows up when sharing the link, and is not at all useful in its current form. Update the page title and description based on the current page. If unset, in post's front matter, it uses defaults from config.toml